### PR TITLE
Add example for localization of Data Annotation attributes

### DIFF
--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Pages/HelloRazor.cshtml
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Pages/HelloRazor.cshtml
@@ -11,6 +11,14 @@
 <form method="post">
     <div class="form-group">
         <label asp-for="Input.InputField"></label><br />
-        <input asp-for="Input.InputField" class="form-control" />
+        <input asp-for="Input.InputField" class="form-control" /><br />
+        <label asp-for="Input.Email"></label><br />
+        <input asp-for="Input.Email" class="form-control" />
+        <br />
+        <span asp-validation-for="Input.Email" data-valmsg-for="Input.Email" data-valmsg-replace="true" class="text-danger"></span>
+        <br />
+        <div class="button">
+            <button type="submit" class="btn btn-default">Jetzt registrieren</button>
+        </div>
     </div>
 </form>

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Pages/HelloRazor.cshtml.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Pages/HelloRazor.cshtml.cs
@@ -28,6 +28,10 @@ namespace Askmethat.Aspnet.JsonLocalizer.TestSample.Pages
         {
             [Display(Name = "InputField")]
             public string InputField { get; set; }
+
+            [EmailAddress]
+            [Required(ErrorMessage = "Hi")]
+            public string Email { get; set; }
         }
 
         public void OnGet()

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Startup.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Startup.cs
@@ -4,13 +4,15 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Askmethat.Aspnet.JsonLocalizer.Extensions;
 using System.Globalization;
+using Askmethat.Aspnet.JsonLocalizer.TestSample.ValidationHelpers;
 using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.Extensions.Configuration;
 
 namespace Askmethat.Aspnet.JsonLocalizer.TestSample
 {
     public class Startup
     {
-#if NETCOREAPP2
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
@@ -18,11 +20,11 @@ namespace Askmethat.Aspnet.JsonLocalizer.TestSample
 
 
         public IConfiguration Configuration { get; }
-#endif
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddSingleton<IValidationAttributeAdapterProvider, LocalizedValidationAttributeAdapterProvider>();
 
             services.AddMvc()
                 .SetCompatibilityVersion(Microsoft.AspNetCore.Mvc.CompatibilityVersion.Version_2_2)

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Startup.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/Startup.cs
@@ -24,6 +24,8 @@ namespace Askmethat.Aspnet.JsonLocalizer.TestSample
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            // If we want to generally lingualize data annotations we can add this middleware.
+            // Otherwise e.g. required DataAnnotations needs to be provided with an ErrorMessage as parameter when used.
             services.AddSingleton<IValidationAttributeAdapterProvider, LocalizedValidationAttributeAdapterProvider>();
 
             services.AddMvc()

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/ValidationHelpers/LocalizedValidationAttributeAdapterProvider.cs
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/ValidationHelpers/LocalizedValidationAttributeAdapterProvider.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
+using Microsoft.Extensions.Localization;
+
+namespace Askmethat.Aspnet.JsonLocalizer.TestSample.ValidationHelpers
+{
+    /// <summary>
+    /// https://stackoverflow.com/a/50230263/3085985
+    /// </summary>
+    public class LocalizedValidationAttributeAdapterProvider : IValidationAttributeAdapterProvider
+    {
+        private readonly ValidationAttributeAdapterProvider _originalProvider = new ValidationAttributeAdapterProvider();
+
+        public IAttributeAdapter GetAttributeAdapter(ValidationAttribute attribute, IStringLocalizer stringLocalizer)
+        {
+            attribute.ErrorMessage = "Validation_" + attribute.GetType().Name.Replace("Attribute", string.Empty);
+
+            // You might need this if you have custom DataTypeAttribute, for us this just creates
+            // "EmailAddress_EmailAddress" instead of "EmailAddress" as key.
+            //if (attribute is DataTypeAttribute dataTypeAttribute)
+            //    attribute.ErrorMessage += "_" + dataTypeAttribute.DataType;
+
+            return _originalProvider.GetAttributeAdapter(attribute, stringLocalizer);
+        }
+    }
+}

--- a/test/Askmethat.Aspnet.JsonLocalizer.TestSample/json/Pages.HelloRazorModel.json
+++ b/test/Askmethat.Aspnet.JsonLocalizer.TestSample/json/Pages.HelloRazorModel.json
@@ -10,5 +10,17 @@
       "en-US": "Write some text.",
       "fr-FR": "Écri un petite texte."
     }
+  },
+  "Validation_EmailAddress": {
+    "Values": {
+      "en-US": "Please provide a valid mail address for {0}.",
+      "fr-FR": "Fournir on mail address valide s'il vous plaît pour {0}."
+    }
+  },
+  "Validation_Required": {
+    "Values": {
+      "en-US": "The {0} field is required. Please provide a value.",
+      "fr-FR": "Le {0} champ est falloir."
+    }
   }
 }


### PR DESCRIPTION
If one tries to lingualize the "Required"-Attribute we observe it is not processed by the lingualization middleware except if we always set the ErrorMessage as a parameter. This behavior and a workaround is shown [here](https://stackoverflow.com/a/50230263/3085985).

This PR adds an example how to use this workaround.